### PR TITLE
feat: add rename functionality to board

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 
 import { Toaster } from "@/components/ui/sonner";
 import { ConvexClientProvider } from "@/providers/convex-client-provider";
+import { ModalProvider } from "@/providers/modal-provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <ConvexClientProvider>
           <Toaster />
+          <ModalProvider />
 
           {children}
         </ConvexClientProvider>

--- a/components/actions.tsx
+++ b/components/actions.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { DropdownMenuContentProps } from "@radix-ui/react-dropdown-menu";
-import { Link2, Trash2 } from "lucide-react";
+import { Link2, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { useApiMutation } from "@/hooks/use-api-mutation";
+import { useRenameModal } from "@/store/use-rename-modal";
 import { api } from "@/convex/_generated/api";
 
 import {
@@ -32,6 +33,7 @@ export const Actions = ({
   id,
   title,
 }: ActionsProps) => {
+  const { onOpen } = useRenameModal();
   const { mutate, pending } = useApiMutation(api.board.remove);
 
   const onCopyLink = () => {
@@ -63,6 +65,14 @@ export const Actions = ({
         >
           <Link2 className="h-4 w-4 mr-2" />
           Copy board link
+        </DropdownMenuItem>
+
+        <DropdownMenuItem
+          className="p-3 cursor-pointer"
+          onClick={() => onOpen(id, title)}
+        >
+          <Pencil className="h-4 w-4 mr-2" />
+          Rename
         </DropdownMenuItem>
 
         <ConfirmModal

--- a/components/modals/rename-modal.tsx
+++ b/components/modals/rename-modal.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogClose,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useRenameModal } from "@/store/use-rename-modal";
+import { FormEventHandler, useEffect, useState } from "react";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import { useApiMutation } from "@/hooks/use-api-mutation";
+import { api } from "@/convex/_generated/api";
+import { toast } from "sonner";
+
+export const RenameModal = () => {
+  const { mutate, pending } = useApiMutation(api.board.update);
+
+  const { isOpen, onClose, initialValues } = useRenameModal();
+  const [title, setTitle] = useState(initialValues.title);
+
+  useEffect(() => {
+    setTitle(initialValues.title);
+  }, [initialValues.title]);
+
+  const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    mutate({
+        id: initialValues.id,
+        title
+    })
+    .then(() => {
+        toast.success("Board removed");
+        onClose();
+    })
+    .catch(() => toast.error("Failed to rename board"));
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={onClose}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit board title</DialogTitle>
+        </DialogHeader>
+
+        <DialogDescription>Enter a new title for this board</DialogDescription>
+
+        <form
+          onSubmit={onSubmit}
+          className="space-y-4"
+        >
+          <Input
+            disabled={pending}
+            required
+            maxLength={60}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Board title"
+          />
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button
+                type="button"
+                variant={"outline"}
+              >
+                Cancel
+              </Button>
+            </DialogClose>
+
+            <Button
+              disabled={pending}
+              type="submit"
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState} from "react";
+
+import { RenameModal } from "@/components/modals/rename-modal";
+
+export const ModalProvider = () => {
+    const [isMounted, setIsMounted] = useState(false);
+
+    // useEffect can only be called when client side rendering is completed
+    // ensure component is only ever rendered on server side
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
+
+    if (!isMounted) {
+        return null;
+    }
+
+    return (
+        <>
+            <RenameModal />
+        </>
+    )
+}

--- a/store/use-rename-modal.ts
+++ b/store/use-rename-modal.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+const defaultValues = { id: "", title: "" };
+
+interface IRenameModal {
+  isOpen: boolean;
+  initialValues: typeof defaultValues;
+  onOpen: (id: string, title: string) => void;
+  onClose: () => void;
+}
+
+export const useRenameModal = create<IRenameModal>((set) => ({
+  isOpen: false,
+  onOpen: (id, title) =>
+    set({ 
+      isOpen: true,
+      initialValues: { id, title },
+    }),
+  onClose: () =>
+    set({
+      isOpen: false,
+      initialValues: defaultValues,
+    }),
+  initialValues: defaultValues,
+}));


### PR DESCRIPTION
- Added a new `RenameModal` component to handle renaming of a board.
- Added a `ModalProvider` component to handle rendering of modals.
- Created a `useRenameModal` store to manage the state of the rename modal.
- Added a new button in the dropdown menu of a board to trigger the rename modal.
- Implemented the logic to update the board title when the form in the rename modal is submitted.