### PR TITLE
feat: add favorite and unfavorite functionality to board cards

### DIFF
--- a/app/(dashboard)/_components/board-card/footer.tsx
+++ b/app/(dashboard)/_components/board-card/footer.tsx
@@ -19,6 +19,15 @@ export const Footer = ({
   onClick,
   disabled,
 }: FooterProps) => {
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    onClick();
+  };
+
   return (
     <div className="relative bg-white p-3">
       <p className="truncate text-[13px] max-w-[calc(100%-20px)]">{title}</p>
@@ -29,7 +38,7 @@ export const Footer = ({
 
       <button
         disabled={disabled}
-        onClick={onClick}
+        onClick={handleClick}
         className={cn(
             "opacity-0 group-hover:opacity-100 transition absolute top-3 right-3 text-muted-foreground hover:text-blue-600",
             disabled && "cursor-not-allowed opacity-75"

--- a/app/(dashboard)/_components/board-card/index.tsx
+++ b/app/(dashboard)/_components/board-card/index.tsx
@@ -8,8 +8,12 @@ import { useAuth } from "@clerk/nextjs";
 
 import { Actions } from "@/components/actions";
 import { Skeleton } from "@/components/ui/skeleton";
+import { api } from "@/convex/_generated/api";
+import { useApiMutation } from "@/hooks/use-api-mutation";
+
 import { Overlay } from "./overlay";
 import { Footer } from "./footer";
+import { toast } from "sonner";
 
 interface BoardCardProps {
   id: string;
@@ -37,6 +41,21 @@ export const BoardCard = ({
   const createdAtLabel = formatDistanceToNow(createdAt, {
     addSuffix: true,
   });
+
+  const { mutate: onFavorite, pending: pendingFavorite } = useApiMutation(
+    api.board.favorite
+  );
+  const { mutate: onUnfavorite, pending: pendingUnfavorite } = useApiMutation(
+    api.board.unfavorite
+  );
+
+  const toggleFavorite = () => {
+    if (isFavorite) {
+      onUnfavorite({ id }).catch(() => toast.error("Failed to unfavorite"));
+    } else {
+      onFavorite({ id, orgId }).catch(() => toast.error("Failed to favorite"));
+    }
+  };
 
   return (
     <Link href={`/board/${id}`}>
@@ -66,8 +85,8 @@ export const BoardCard = ({
           title={title}
           authorLabel={authorLabel}
           createdAtLabel={createdAtLabel}
-          onClick={() => {}}
-          disabled={false}
+          onClick={toggleFavorite}
+          disabled={pendingFavorite || pendingUnfavorite}
         />
       </div>
     </Link>

--- a/app/(dashboard)/_components/board-list.tsx
+++ b/app/(dashboard)/_components/board-list.tsx
@@ -70,7 +70,7 @@ export const BoardList = ({ orgId, query }: BoardListProps) => {
             authorName={board.authorName}
             createdAt={board._creationTime}
             orgId={board.orgId}
-            isFavorite={false}
+            isFavorite={board.isFavorite}
           />
         ))}
       </div>

--- a/convex/board.ts
+++ b/convex/board.ts
@@ -79,4 +79,81 @@ export const update = mutation({
 
         return board;
     }
-})
+});
+
+export const favorite = mutation({
+    args: { id: v.id("boards"), orgId: v.string() },
+    handler: async (ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+
+        if (!identity) {
+            throw new Error("Unauthorized");
+        }
+
+        const board = await ctx.db.get(args.id);
+
+        if (!board) {
+            throw new Error("Board not found");
+        }
+
+        const userId = identity.subject;
+
+        const existingFavorite = await ctx.db
+            .query("userFavorites")
+            .withIndex("by_user_board_org", (q) => 
+                q
+                .eq("userId", userId)
+                .eq("boardId", board._id)
+                .eq("orgId", args.orgId)
+            )
+            .unique();
+
+        if (existingFavorite) {
+            throw new Error("Board already favorited");
+        }
+
+        await ctx.db.insert("userFavorites", {
+            userId,
+            boardId: board._id,
+            orgId: args.orgId,
+        });
+
+        return board;
+    }
+});
+
+export const unfavorite = mutation({
+    args: { id: v.id("boards") },
+    handler: async (ctx, args) => {
+        const identity = await ctx.auth.getUserIdentity();
+
+        if (!identity) {
+            throw new Error("Unauthorized");
+        }
+
+        const board = await ctx.db.get(args.id);
+
+        if (!board) {
+            throw new Error("Board not found");
+        }
+
+        const userId = identity.subject;
+
+        const existingFavorite = await ctx.db
+            .query("userFavorites")
+            .withIndex("by_user_board", (q) => 
+                q
+                .eq("userId", userId)
+                .eq("boardId", board._id)
+            )
+            .unique();
+
+        if (!existingFavorite) {
+            throw new Error("Favorited board not found");
+        }
+
+        await ctx.db.delete(existingFavorite._id);
+
+        return board;
+    }
+});

--- a/convex/boards.ts
+++ b/convex/boards.ts
@@ -19,6 +19,25 @@ export const get = query({
             .order("desc")
             .collect();
 
-        return boards;
+        const boardsWithFavoriteRelation = boards.map((board) => {
+            return ctx.db
+                .query("userFavorites")
+                .withIndex("by_user_board", (q) =>
+                    q
+                        .eq("userId", identity.subject)
+                        .eq("boardId", board._id)
+                )
+                .unique()
+                .then((favorite) => {
+                    return {
+                        ...board,
+                        isFavorite: !!favorite,
+                    }
+                })
+        });
+
+        const boardsWithFavoriteBoolean = Promise.all(boardsWithFavoriteRelation);
+
+        return boardsWithFavoriteBoolean;
     }
 })

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,4 +14,13 @@ export default defineSchema({
         searchField: "title",
         filterFields: ["orgId"]
     }),
+    userFavorites: defineTable({
+        orgId: v.string(),
+        userId: v.string(),
+        boardId: v.id("boards")
+    })
+    .index("by_board", ["boardId"])
+    .index("by_user_org", ["userId", "orgId"])
+    .index("by_user_board", ["userId", "boardId"])
+    .index("by_user_board_org", ["userId", "boardId", "orgId"])
 })


### PR DESCRIPTION
- Added `api` and `useApiMutation` imports from `@/convex/_generated/api` and `@/hooks/use-api-mutation`
- Added `onFavorite` and `onUnfavorite` mutations using `useApiMutation` hook
- Created `toggleFavorite` function to handle toggling the favorite status of a board
- Updated `onClick` and `disabled` props of `BoardCard` component to use `toggleFavorite` and `pendingFavorite` and `pendingUnfavorite` respectively
- Added `isFavorite` prop to `BoardCard` component to display the favorite status of a board
- Updated `getBoards` resolver to include the favorite status of each board
- Updated `Footer` component to handle the `onClick` event and prevent default behavior
- Updated `onClick` prop of `Footer` component to use `handleClick` function
- Added `favorite` and